### PR TITLE
Tolerating no ZMQ, Protobuf version

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -27,7 +27,7 @@ jobs:
           rm -rf /usr/local/var/homebrew/locks
           brew cleanup -s
           brew update
-          brew install mosquitto zeromq qt@5
+          brew install mosquitto zeromq qt@5 protobuf@21
 
       - name: Build PlotJuggler
         run: |

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -87,7 +87,7 @@ docker buildx build -o . .
 On Mac, the dependencies can be installed using [brew](https://brew.sh/) with the following command:
 
 ```shell
-brew install cmake qt@5 protobuf mosquitto zeromq zstd
+brew install cmake qt@5 protobuf@21 mosquitto zeromq zstd
 ```
 
 If you have multiple versions of Qt installed (e.g., `qt` and `qt@5`), you may need to explicitly link `qt@5` to ensure it is found by CMake. Use the following commands:
@@ -120,7 +120,7 @@ export LDFLAGS="$QT_HOME/lib"
 Clone the repository into **~/plotjuggler_ws**:
 
 ```shell
-git clone https://github.com/PX4/PlotJuggler.git ~/plotjuggler_ws/src/PlotJuggler
+git clone https://github.com/facontidavide/PlotJuggler.git ~/plotjuggler_ws/src/PlotJuggler
 cd ~/plotjuggler_ws
 ```
 

--- a/plotjuggler_plugins/DataStreamZMQ/CMakeLists.txt
+++ b/plotjuggler_plugins/DataStreamZMQ/CMakeLists.txt
@@ -4,30 +4,34 @@ elseif(BUILDING_WITH_CONAN)
     message(STATUS "Finding ZeroMQ with conan")
 else()
     message(STATUS "Finding ZeroMQ without package managers")
-    set(ZeroMQ_LIBS ${ZeroMQ_LIBRARIES})
 endif()
 
 find_package(ZeroMQ QUIET)
 
 if(ZeroMQ_FOUND)
-    # message(STATUS "[ZeroMQ] found")
+    message(STATUS "[ZeroMQ] found at ${ZeroMQ_INCLUDE_DIR} and ${ZeroMQ_LIBRARY}")
 
-    # add_definitions(${QT_DEFINITIONS})
-    # add_definitions(-DQT_PLUGIN)
+    add_definitions(${QT_DEFINITIONS})
+    add_definitions(-DQT_PLUGIN)
+    include_directories(${ZeroMQ_INCLUDE_DIR})
 
-    # QT5_WRAP_UI ( UI_SRC  datastream_zmq.ui  )
+    QT5_WRAP_UI(UI_SRC datastream_zmq.ui)
 
-    # add_library(DataStreamZMQ SHARED datastream_zmq.cpp ${UI_SRC}  )
+    add_library(DataStreamZMQ SHARED datastream_zmq.cpp ${UI_SRC})
 
-    # target_link_libraries(DataStreamZMQ ${Qt5Widgets_LIBRARIES} plotjuggler_base)
+    target_link_libraries(DataStreamZMQ
+        ${Qt5Widgets_LIBRARIES}
+        plotjuggler_base
+        ${ZeroMQ_LIBRARIES}
+    )
 
-    # if(BUILDING_WITH_VCPKG OR BUILDING_WITH_CONAN)
-    #     target_link_libraries(DataStreamZMQ libzmq-static)
-    # else()
-    #     target_link_libraries(DataStreamZMQ ${ZeroMQ_LIBRARIES})
-    # endif()
+    if(BUILDING_WITH_VCPKG OR BUILDING_WITH_CONAN)
+        target_link_libraries(DataStreamZMQ libzmq-static)
+    endif()
 
-    # install(TARGETS DataStreamZMQ DESTINATION ${PJ_PLUGIN_INSTALL_DIRECTORY}  )
+    install(TARGETS DataStreamZMQ
+        DESTINATION ${PJ_PLUGIN_INSTALL_DIRECTORY}
+    )
 else()
-    message("[ZeroMQ] not found. Skipping plugin DataStreamZMQ.")
+    message(WARNING "[ZeroMQ] not found. Skipping plugin DataStreamZMQ.")
 endif()


### PR DESCRIPTION
- reverts suppressing ZMQ in build and adds tolerance for ZMQ not available. 
- Fixes protobuf version (needs to be 21 for now so error collectors can be happy)
- Updated CI for protobuf version. 